### PR TITLE
Support url with subfolder

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_MAPBOX_TOKEN=get_your_own_token
+BASE_PATH=base_path_of_next_app_should_start_with_/

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    basePath: process.env.BASE_PATH
+}  

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,3 @@
 module.exports = {
     basePath: process.env.BASE_PATH
-}  
+}


### PR DESCRIPTION
Hi,

If app is deployed in subfolder of domain name (i.e. http://example.com/velos-paris), index cannot load asset (index look at http://example.com/_next ...).

When adding config with basePath, build automatically add prefix to links (https://nextjs.org/docs/api-reference/next.config.js/basepath).

Thomas