### PR TITLE
Rendre ce dépôt utilisable par d'autres villes/assos (resolves #22)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,4 @@
 NEXT_PUBLIC_MAPBOX_TOKEN=get_your_own_token
+NEXT_PUBLIC_MAPBOX_CENTER="48.86,2.34"
+NEXT_PUBLIC_MAPBOX_ZOOM=11.4
 BASE_PATH=base_path_of_next_app_should_start_with_/

--- a/components/map.tsx
+++ b/components/map.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import _ from 'lodash';
 import * as d3 from 'd3-scale';
 import slugify from 'slugify';
-
+import { parseCoord } from '../lib/helpers';
 import { CounterStat } from '../lib/types.d';
 
 const popupHTML = (counter: CounterStat): string => `
@@ -51,8 +51,8 @@ const Map = ({ counters, highlight }: Props) => {
     const newMap = new mapboxgl.Map({
       container: mapContainer.current,
       style: 'mapbox://styles/mapbox/streets-v11',
-      center: [2.34, 48.86],
-      zoom: 11.4,
+      center: parseCoord(process.env.NEXT_PUBLIC_MAPBOX_CENTER),
+      zoom: parseFloat(process.env.NEXT_PUBLIC_MAPBOX_ZOOM),
     });
     newMap.addControl(new mapboxgl.NavigationControl());
     newMap.on('load', () => {

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { CounterMetadata, CounterSummary, CounterStat } from './types';
 
-const parseCoord = (coord: string): [number, number] => {
+export const parseCoord = (coord: string): [number, number] => {
   const parts = coord.split(',');
   return [Number(parts[1]), Number(parts[0])];
 };

--- a/pages/details/[counter].tsx
+++ b/pages/details/[counter].tsx
@@ -45,13 +45,19 @@ const fmtDate = (detail: CounterDetails, format: string): string => {
   return DateTime.fromISO(detail.time).toFormat(format);
 };
 
+const ImageComponent = function({detail} : {detail: Detail}) {
+  if (detail.img) {
+    return <a href={detail.img} target="blank">
+      <img src={detail.img} alt={`Image du compteur${detail.name}`} />
+    </a>;
+  }
+  return null;
+}
 const DetailComponent = ({ detail }: { detail: Detail }) => (
   <div className="rounded-xl p-6 bg-white mb-4">
     <h3>{detail.name}</h3>
     <p>Installé le {detail.date}</p>
-    <a href={detail.img} target="blank">
-      <img src={detail.img} alt={`Image du compteur${detail.name}`} />
-    </a>
+    <ImageComponent detail={detail}/>
     <SingleMarker coord={detail.coord} />
   </div>
 );


### PR DESCRIPTION
Bonjour,

Cette pull request permet de configurer la carte depuis le fichier des variables d'environnement (.env.local). 
J'ai inséré dans le .env.local.example les valeurs qui été originalement dans le code.

Enfin la photo n'est plus obligatoire.

Comme @Tristramg me l'a suggéré, j'ai fait au plus simple. Il suffira aux différentes assos de faire des scripts pour coller aux formats des exports parisiens. Nous verrons plus tard s'il est nécessaire de faire une couche d'abstraction pour configurer le mapping entre entête csv et code.

Pour plus d'infos, se référer l'issue #22.

Paul