### PR TITLE
Modif  comptage des jours d'activité d'un point de passage

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -35,7 +35,7 @@ const merge = (counters: CounterStat[], id: string): CounterStat => ({
   id,
   label: id,
   strippedLabel: id,
-  days: _.sumBy(counters, 'days'),
+  days: _.sumBy(counters, 'days')/counters.length,
   total: _.sumBy(counters, 'total'),
   day: _.sumBy(counters, 'day'),
   month: _.sumBy(counters, 'month'),


### PR DESCRIPTION
le décompte du nombre de jour était faussé par la présence de plusieurs compteurs sur un site.
Regarder par exemple 
Avenue Daumesnil : 1 compteur. Historique de 421 jours. Moyenne journalière semblable aux autres statistiques
à peu près tous les autres : 2 compteurs. Historique de 842 jours. Moyenne journalière moitié moins importante pour cette stat que pour les autres.
La correction compte correctement le nombre de jours (sous réserve que le nombre de totems ne varie pas pour la station avec le temps)
