### PR TITLE
Update heatmap.tsx

### DIFF
--- a/components/heatmap.tsx
+++ b/components/heatmap.tsx
@@ -17,37 +17,41 @@ const Heatmap = ({ counters }: Props) => {
         values: counters['year_daily'],
       },
       title: 'Passages journaliers',
-      config: { view: { strokeWidth: 0, step: 20 }, axis: { domain: false } },
-      mark: 'rect',
+      config: { view: { strokeWidth: 0, step: 15 }, axis: { domain: false } },
+      "mark": {"type": "rect", "height": 6},
       encoding: {
-        x: {
+     x: {
           field: 'time',
-          timeUnit: 'date',
+          timeUnit: 'day',
           type: 'ordinal',
-          title: 'Jour',
-          axis: { labelAngle: 0, format: '%e' },
+          title: 'Jour de la semaine',
         },
         y: {
           field: 'time',
-          timeUnit: 'month',
+          timeUnit: 'yearweek',
           type: 'ordinal',
-          title: 'Mois',
+          title: 'Semaine',
+          scale: {
+            padding: -3
+          },
         },
         color: {
           field: 'count',
           aggregate: 'sum',
           type: 'quantitative',
           legend: { title: 'Passages' },
+          scale: { scheme: "viridis" }
         },
-        tooltip: [
+        "tooltip": [
           {
-            field: 'time',
-            title: 'Date',
-            type: 'temporal',
-            format: '%e %b %Y',
+            "field": "time",
+            "title": "Date",
+            "type": "temporal",
+            "format": "%e %b %Y"
           },
-          { field: 'count', aggregate: 'sum', title: 'Passages' },
-        ],
+          { "field": "count", "aggregate": "sum", "title": "Passages" }
+        ]
+  ],
       },
     };
     vegaEmbed(container.current, vegaSpec, { timeFormatLocale }).then((r) => r);


### PR DESCRIPTION
Une mise à jour pour 
* éviter le changement de date en cours d'année
* regrouper les données en semaines plutôt qu'en mois. C'est plus parlant ! En revanche, j'ai un peu bidouiller pour que les lignes ne prennent pas trop de place.
Je l'ai fait pour https://compteurs.parisenselle.fr/details/Boulevard-de-Sebastopol et cela donne
![image](https://user-images.githubusercontent.com/25034898/234647364-7fb40e40-2633-4af2-a090-a97c2753167e.png)

à la place de 
![image](https://user-images.githubusercontent.com/25034898/234647928-bcd06c76-7d02-413f-9263-dd89f40f1896.png)


on peut avoir un aperçu sur le brouillon du site pour Strasbourg
(https://strasbourgvelo.fr/details/Place-du-Corbeau)
