### PR TITLE
feat(heatmap): Start weeks on Monday (instead of Sunday)

### DIFF
--- a/components/heatmap.tsx
+++ b/components/heatmap.tsx
@@ -25,6 +25,7 @@ const Heatmap = ({ counters }: Props) => {
           timeUnit: 'day',
           type: 'ordinal',
           title: 'Jour de la semaine',
+          sort: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
         },
         y: {
           field: 'time',


### PR DESCRIPTION
Bonjour Tristram, merci pour ton super boulot sur la dataviz des compteurs, comme tu le sais peut-être on l'a légèrement adapté et déployé à Bordeaux : https://compteurs.velo-cite.org

Voici une PR qui concerne un point de détail : dans la heatmap, faire commencer les semaines par le lundi, et non par le dimanche ; en espérant que ça puisse t'être utile.