### PR TITLE
[Responsive] fix largeur des barcharts (600 to container) fix #26

### DIFF
--- a/components/plot.tsx
+++ b/components/plot.tsx
@@ -114,7 +114,7 @@ const Plot = ({ counters, period }: Props) => {
           groupby: ['time'],
         },
       ],
-      width: 600,
+      width: "container",
       mark: 'bar',
       encoding: {
         x: {

--- a/components/plot.tsx
+++ b/components/plot.tsx
@@ -114,7 +114,7 @@ const Plot = ({ counters, period }: Props) => {
           groupby: ['time'],
         },
       ],
-      width: "container",
+      width: 'container',
       mark: 'bar',
       encoding: {
         x: {


### PR DESCRIPTION
Salut,

Je viens de corriger la largeur des barcharts. 
Ceci corrige le problème d'affichage sur téléphone.

La largeur passe de 600px à la taille du container (qui peux être inférieur à 600px).

C'est pas parfait lorsqu'il y a trop de données mais ça a le mérite de corriger l'affichage.

![Screenshot_20240203-183057](https://github.com/Tristramg/velos-paris/assets/3404409/42efcb48-9e2d-49cb-8c51-3d9524ed034b)


Une autre correction est possible et peut être même préférable afin de garder la lisibilité des bars : garder la largeur de 600px mais l'insérer dans un container plus petit. Cela imposera à l'utilisateur de scroller horizontalement mais c'est beaucoup plus lisible.
Pour éviter ça 
![Capture d’écran du 2024-02-04 10-40-30](https://github.com/Tristramg/velos-paris/assets/3404409/48df406f-f09f-4347-b928-d91bfcfd9369)


et avoir ça à la place : 
![Capture d’écran du 2024-02-04 10-36-22](https://github.com/Tristramg/velos-paris/assets/3404409/205702dd-392b-4cbe-ac12-6652e212fa84)

fix #26 